### PR TITLE
Small test fixes to bypass warnings

### DIFF
--- a/tests/test_ellipsoidal_density_projection.py
+++ b/tests/test_ellipsoidal_density_projection.py
@@ -19,15 +19,18 @@ def add_default_params(frame):
 
 
 TEST_SINGLE_FRAME = add_default_params(
-    ase.Atoms(symbols=["X"], positions=np.zeros((1, 3)), cell=(10, 10, 10), pbc=False)
+    ase.Atoms(symbols=["X"], positions=np.zeros((1, 3)), cell=(0, 0, 0), pbc=False)
 )
 TEST_QUAT_FRAME = add_default_params(
     ase.Atoms(
-        symbols=["X", "O"], positions=[np.zeros(3), np.ones(3)], cell=(10, 10, 10)
+        symbols=["X", "O"], positions=[np.zeros(3), np.ones(3)], cell=(0, 0, 0)
     )
 )
 TEST_MATRIX_FRAME = TEST_SINGLE_FRAME.copy()
 TEST_MATRIX_FRAME.arrays["matrix"] = [np.eye(3)]
+
+print(TEST_SINGLE_FRAME.arrays)
+print(TEST_QUAT_FRAME.arrays)
 
 TEST_FRAMES = [
     [TEST_SINGLE_FRAME],
@@ -60,13 +63,13 @@ class TestEllipsoidalDensityProjection:
             frames, show_progress=True
         )
 
-    @pytest.mark.parametrize("frames", TEST_FRAMES)
+    @pytest.mark.parametrize("frames", [[TEST_MATRIX_FRAME]])
     def test_frames_matrix_rotation(self, frames):
         EllipsoidalDensityProjection(
             rotation_key="matrix", rotation_type="matrix", **DEFAULT_HYPERS
         ).transform(frames, show_progress=True)
 
-    @pytest.mark.parametrize("frames", TEST_FRAMES)
+    @pytest.mark.parametrize("frames", [[TEST_MATRIX_FRAME]])
     def test_frames_normalization_condition(self, frames):
         edp = EllipsoidalDensityProjection(
             rotation_key="matrix", rotation_type="matrix", **DEFAULT_HYPERS

--- a/tests/test_ellipsoidal_density_projection.py
+++ b/tests/test_ellipsoidal_density_projection.py
@@ -27,9 +27,6 @@ TEST_QUAT_FRAME = add_default_params(
 TEST_MATRIX_FRAME = TEST_SINGLE_FRAME.copy()
 TEST_MATRIX_FRAME.arrays["matrix"] = [np.eye(3)]
 
-print(TEST_SINGLE_FRAME.arrays)
-print(TEST_QUAT_FRAME.arrays)
-
 TEST_FRAMES = [
     [TEST_SINGLE_FRAME],
     [TEST_QUAT_FRAME],

--- a/tests/test_ellipsoidal_density_projection.py
+++ b/tests/test_ellipsoidal_density_projection.py
@@ -22,9 +22,7 @@ TEST_SINGLE_FRAME = add_default_params(
     ase.Atoms(symbols=["X"], positions=np.zeros((1, 3)), cell=(0, 0, 0), pbc=False)
 )
 TEST_QUAT_FRAME = add_default_params(
-    ase.Atoms(
-        symbols=["X", "O"], positions=[np.zeros(3), np.ones(3)], cell=(0, 0, 0)
-    )
+    ase.Atoms(symbols=["X", "O"], positions=[np.zeros(3), np.ones(3)], cell=(0, 0, 0))
 )
 TEST_MATRIX_FRAME = TEST_SINGLE_FRAME.copy()
 TEST_MATRIX_FRAME.arrays["matrix"] = [np.eye(3)]


### PR DESCRIPTION
Saw some errant warnings when reviewing #46. We generally want to keep these types of warnings to a minimum to avoid output clutter.