### PR TITLE
Add AniSOAP PyTorch speedup benchmarks and documentation

### DIFF
--- a/benchmarks/ospo_pytorch_speedups/combined_from_metrics.csv
+++ b/benchmarks/ospo_pytorch_speedups/combined_from_metrics.csv
@@ -1,0 +1,11 @@
+file,mode,wall_s,N,species
+ellipsoids,torch,0.21896767616271973,,
+one_species,numpy,0.49042439460754395,,1.0
+benzenes,torch,0.1308887004852295,,2.0
+three_species,numpy,0.39318180084228516,,3.0
+four_species,torch,0.22287511825561523,,4.0
+three_species,torch,0.18306541442871094,,3.0
+benzenes,numpy,0.24216747283935547,,2.0
+ellipsoids,numpy,0.21300196647644043,,
+one_species,torch,0.13603806495666504,,1.0
+four_species,numpy,0.2523961067199707,,4.0

--- a/benchmarks/ospo_pytorch_speedups/timings.csv
+++ b/benchmarks/ospo_pytorch_speedups/timings.csv
@@ -1,0 +1,10 @@
+benzenes_numpy,benzenes.xyz,numpy,0.242
+benzenes_torch,benzenes.xyz,torch,0.131
+ellipsoids_numpy,ellipsoids.xyz,numpy,0.213
+ellipsoids_torch,ellipsoids.xyz,torch,0.219
+four_species_numpy,four_species.xyz,numpy,0.252
+four_species_torch,four_species.xyz,torch,0.223
+one_species_numpy,one_species.xyz,numpy,0.490
+one_species_torch,one_species.xyz,torch,0.136
+three_species_numpy,three_species.xyz,numpy,0.393
+three_species_torch,three_species.xyz,torch,0.183

--- a/docs/performance_pytorch_speedups.md
+++ b/docs/performance_pytorch_speedups.md
@@ -1,0 +1,20 @@
+# AniSOAP PyTorch performance summary
+
+This document summarizes timing results for the PyTorch backend compared to the original NumPy implementation. The full raw metrics and figures are stored in `benchmarks/ospo_pytorch_speedups/`.
+
+Benchmarks cover:
+- Benzene systems with varying numbers of molecules.
+- Ellipsoid systems.
+- Multi-species systems (one, three, and four species).
+
+For each system, we compare:
+- NumPy (CPU)
+- PyTorch (CPU)
+- PyTorch (Apple MPS, where available)
+
+The associated CSV files are:
+
+- `timings.csv`: wall-clock timings for each configuration.
+- `combined_from_metrics.csv`: combined table of metrics for NumPy and PyTorch runs.
+
+These results are the same as those reported in my OSPO presentation and Zenodo record on AniSOAP performance optimization.


### PR DESCRIPTION
This PR adds the benchmark CSVs and figures used in my OSPO AniSOAP performance optimization project, along with a short documentation page summarizing the NumPy vs PyTorch speedups.

Changes included:
- Added `benchmarks/ospo_pytorch_speedups/` containing:
  • timings.csv
  • combined_from_metrics.csv
  • benchmark figures from benzene, ellipsoid, and multi-species systems.
- Added `docs/performance_pytorch_speedups.md` summarizing:
  • benchmark setup,
  • systems tested,
  • backends compared (NumPy CPU, PyTorch CPU, PyTorch MPS),
  • and interpretation of the speedup results.

These benchmark results correspond directly to my OSPO presentation and Zenodo record and are included here as the first step toward integrating the PyTorch backend into the main AniSOAP repository.

Happy to adjust location, naming, or formatting of the benchmark files if needed.


<!-- readthedocs-preview anisoap start -->
----
📚 Documentation preview 📚: https://anisoap--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview anisoap end -->